### PR TITLE
Make client menu run actions

### DIFF
--- a/client.c
+++ b/client.c
@@ -1753,7 +1753,7 @@ void client_switcher(unsigned int tag)
 	{
 		display = XOpenDisplay(0);
 		XSync(display, True);
-		int n = menu(list, NULL, 1);
+		int n = menu(list, NULL, 1, MENU_CLIENT_LIST);
 		if (n >= 0 && list[n])
 			window_send_message(root, ids->array[n], netatoms[_NET_ACTIVE_WINDOW], 2, // 2 = pager
 				SubstructureNotifyMask | SubstructureRedirectMask);

--- a/goomwwm.h
+++ b/goomwwm.h
@@ -352,6 +352,11 @@ typedef struct {
 } client;
 
 // built-in filterable popup menu list
+enum MENU_TYPE {
+	MENU_CLIENT_LIST,
+	MENU_TAG_LIST,
+	MENU_RULE_LIST
+};
 struct localmenu {
 	Window window;
 	GC gc;
@@ -367,6 +372,7 @@ struct localmenu {
 	char *input, *selected, *manual;
 	XIM xim;
 	XIC xic;
+	enum MENU_TYPE type;
 };
 
 // config settings

--- a/menu.c
+++ b/menu.c
@@ -24,6 +24,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
+static void perform_menu_action(struct localmenu *my);
+
 // redraw the popup menu window
 void menu_draw(struct localmenu *my)
 {
@@ -114,7 +116,7 @@ void menu_key(struct localmenu *my, XEvent *ev)
 }
 
 // menu
-int menu(char **lines, char *manual, int firstsel)
+int menu(char **lines, char *manual, int firstsel, enum MENU_TYPE type)
 {
 	int i, l;
 	struct localmenu _my, *my = &_my;
@@ -147,6 +149,7 @@ int menu(char **lines, char *manual, int firstsel)
 	my->xbg         = color_get(config_menu_bg);
 	my->selected    = NULL;
 	my->manual      = manual;
+	my->type	= type;
 
 	int x = mon.x + ((mon.w - my->width)/2);
 	int y = mon.y + (mon.h/2) - (my->height/2);
@@ -195,6 +198,14 @@ int menu(char **lines, char *manual, int firstsel)
 	XftFontClose(display, my->font);
 	XDestroyWindow(display, my->window);
 	release_keyboard();
+
+	/*
+	 * Check to see if we're performing an action instead; this implies a
+	 * non-selected item.
+	 */
+	if ((my->manual == NULL && my->selected == NULL) && my->input)
+		perform_menu_action(my);
+
 	free(my->input);
 
 	if (my->selected)
@@ -202,4 +213,20 @@ int menu(char **lines, char *manual, int firstsel)
 			if (my->lines[i] == my->selected)
 				return i;
 	return -1;
+}
+
+void perform_menu_action(struct localmenu *my)
+{
+	switch (my->type)
+	{
+	case MENU_CLIENT_LIST:
+		execsh(my->input);
+	case MENU_TAG_LIST:
+		/* FALLTHROUGH */
+	case MENU_RULE_LIST:
+		/* Not implemented yet. */
+		return;
+	default:
+		return;
+	}
 }

--- a/proto.h
+++ b/proto.h
@@ -108,7 +108,7 @@ void handle_mappingnotify(XEvent *ev);
 void menu_draw(struct localmenu *my);
 void menu_select_current(struct localmenu *my);
 void menu_key(struct localmenu *my, XEvent *ev);
-int menu(char **lines, char *manual, int firstsel);
+int menu(char **lines, char *manual, int firstsel, enum MENU_TYPE);
 void monitor_dimensions(int x, int y, workarea *mon);
 void monitor_dimensions_struts(int x, int y, workarea *mon);
 void monitor_active(workarea *mon);

--- a/rule.c
+++ b/rule.c
@@ -109,7 +109,7 @@ void ruleset_switcher()
 	{
 		display = XOpenDisplay(0);
 		XSync(display, True);
-		int n = menu(list, NULL, 0);
+		int n = menu(list, NULL, 0, MENU_RULE_LIST);
 		if (n >= 0 && list[n])
 		{
 			cli_message(gatoms[GOOMWWM_RULESET], list[n]);


### PR DESCRIPTION
Sean,

Please see the following.  One of many little hacks to come:

When issuing the client menu, and filtering the results, if what's entered
is not found in the menu, execute it as a command instead.

This makes the client menu work more like a launcher, without the direct
need for dmneu; furthermore, it also acts as a "swich to window if exists,
else run that command" filter, which can be handy.

This also makes the menu an enum type, which means other menu types in the
future (such as the tag menu, or rulesets menu) can have similar actions if
required.  Currently, only implemented for the client menu though.
