### PR TITLE
Honour XUrgencyHint

### DIFF
--- a/client.c
+++ b/client.c
@@ -1095,8 +1095,14 @@ void client_full_review(client *c)
 // update client border to blurred
 void client_deactivate(client *c, client *a)
 {
-	XSetWindowBorder(display, c->window, client_has_state(c, netatoms[_NET_WM_STATE_DEMANDS_ATTENTION])
-		? config_border_attention: config_border_blur);
+	XWMHints *hint;
+	hint = XGetWMHints(display, c->window);
+
+	XSetWindowBorder(display, c->window,
+		(client_has_state(c, netatoms[_NET_WM_STATE_DEMANDS_ATTENTION]) ||
+		 hint->flags & XUrgencyHint) ? config_border_attention :
+		 config_border_blur);
+
 	if (c->visible && client_rule(c, RULE_AUTOMINI))
 	{
 		bool trans = 0;

--- a/handle.c
+++ b/handle.c
@@ -869,11 +869,17 @@ void handle_propertynotify(XEvent *ev)
 {
 //	while (XCheckTypedWindowEvent(display, ev->xproperty.window, PropertyNotify, ev));
 	XPropertyEvent *p = &ev->xproperty;
+	XWMHints *hint;
 	client *c = client_create(p->window);
 	if (c && c->visible && c->manage)
 	{
-		if (p->atom == netatoms[_NET_WM_STATE_DEMANDS_ATTENTION] && !c->active)
+		hint = XGetWMHints(display, p->window);
+		if ((p->atom == netatoms[_NET_WM_STATE_DEMANDS_ATTENTION] ||
+			hint->flags & XUrgencyHint) && !c->active)
+		{
 			client_deactivate(c, client_active(0));
+			XFree(hint);
+		}
 	}
 	// clear monitor workarea/strut cache
 	if (p->atom == netatoms[_NET_WM_STRUT] || p->atom == netatoms[_NET_WM_STRUT_PARTIAL])


### PR DESCRIPTION
Sean,

See the following:

Not all applications use _NET_WM_DEMANDS_ATTENTION when dealing with BEL
characters, etc.

At this point it's a gross hack -- there's plenty more instances where a combination of both _NET_WM\* atoms and ICCCM atoms will need to be looked for, so some generic functions to handle this would be a better direction to go in.  This currently works for me though in the case of setting urgency on windows which don't use _NET_WM_DEMANDS_ATTENTION
