### PR TITLE
Add a FreeBSD Makefile

### DIFF
--- a/Makefile.freebsd
+++ b/Makefile.freebsd
@@ -1,0 +1,19 @@
+CFLAGS+=-Wall -O2 -I/usr/local/include -I/usr/local/include/freetype2
+LDADD+=-lutil -L/usr/local/lib -lX11 -lXft -lXinerama -lXrender -lfontconfig -lfreetype
+
+normal:
+	$(CC) -o goomwwm goomwwm.c $(CFLAGS) $(LDADD) $(LDFLAGS) 
+
+debug:
+	$(CC) -o goomwwm-debug goomwwm.c $(CFLAGS) -g -DDEBUG $(LDADD)
+
+proto:
+	cat *.c | egrep '^(void|int|char|unsigned|client|Window|winlist|XWindow)' | sed -r 's/\)/);/' > proto.h
+
+docs:
+	pandoc -s -w man goomwwm.md -o goomwwm.1
+
+all: proto normal debug docs
+
+clean:
+	rm -f goomwwm goomwwm-debug


### PR DESCRIPTION
Sean,

I had to tweak the Makefile to get goomwwm to compile on FreeBSD.  To that end, I've put those tweaks in Makefile.freebsd.  See the commit message below.  I am not sure though how you plan to handle goomwwm on non-Linux platforms, but I don't consider specific Makefiles per platform a problem.  The only thing I've not done is document this, of course.  Whilst the compilation is not without gcc warnings, it does at least work on FreeBSD.

Kindly,

-- Thomas Adam

Some tweaks to the default Makefile were needed to get goomwwm to
compile on FreeBSD.  Those are now contained in their own Makefile
as Makefile.freebsd, and users on that platform should issue:

make -f Makefile.freebsd
