### PR TITLE
Honour resize increments

### DIFF
--- a/client.c
+++ b/client.c
@@ -355,6 +355,7 @@ void client_moveresize(client *c, int smart, int fx, int fy, int fw, int fh)
 	client_extended_data(c);
 	fx = MAX(0, fx); fy = MAX(0, fy);
 	int bw = c->border_width ? config_border_width*2: 0;
+	int basew = 0, baseh = 0;
 
 	// this many be different to the client's current c->monitor...
 	workarea monitor; monitor_dimensions_struts(fx, fy, &monitor);
@@ -380,6 +381,13 @@ void client_moveresize(client *c, int smart, int fx, int fy, int fw, int fh)
 		fh = MAX(MINWINDOW, MIN(fh, monitor.h));
 
 		// process size hints
+		if (c->xsize.flags & PBaseSize)
+		{
+			basew = c->xsize.base_width;
+			baseh = c->xsize.base_height;
+		}
+		fw -= basew; fh -= baseh;
+
 		if (c->xsize.flags & PMinSize)
 		{
 			// fw/fh still include borders here
@@ -400,6 +408,13 @@ void client_moveresize(client *c, int smart, int fx, int fy, int fw, int fh)
 				if (ratio < minr) fh = (int)(fw / minr);
 			else if (ratio > maxr) fw = (int)(fh * maxr);
 		}
+
+		if (c->xsize.flags & PResizeInc)
+		{
+			fw -= fw % c->xsize.width_inc;
+			fh -= fh % c->xsize.height_inc;
+		}
+		fw += basew; fh += baseh;
 
 		// bump onto screen. shrink if necessary
 		//fw = MAX(MINWINDOW, MIN(fw, monitor.w));

--- a/handle.c
+++ b/handle.c
@@ -380,6 +380,7 @@ void handle_buttonrelease(XEvent *ev)
 // only get these if a window move/resize has been started in buttonpress
 void handle_motionnotify(XEvent *ev)
 {
+	int basew = 0, baseh = 0;
 	// compress events to reduce window jitter and CPU load
 	while(XCheckTypedEvent(display, MotionNotify, ev));
 	client *c = client_create(ev->xmotion.window);
@@ -453,6 +454,13 @@ void handle_motionnotify(XEvent *ev)
 			}
 		}
 		// process size hints
+		if (c->xsize.flags & PBaseSize)
+		{
+			basew = c->xsize.base_width;
+			baseh = c->xsize.base_height;
+		}
+
+		w -= basew; h -= baseh;
 		if (c->xsize.flags & PMinSize)
 		{
 			w = MAX(w, c->xsize.min_width);
@@ -471,6 +479,12 @@ void handle_motionnotify(XEvent *ev)
 				if (ratio < minr) h = (int)(w / minr);
 			else if (ratio > maxr) w = (int)(h * maxr);
 		}
+		if (c->xsize.flags & PResizeInc)
+		{
+			w -= w % c->xsize.width_inc;
+			h -= h % c->xsize.height_inc;
+		}
+		w += basew; h += baseh;
 		w = MAX(MINWINDOW, w); h = MAX(MINWINDOW, h);
 		XMoveResizeWindow(display, ev->xmotion.window, x, y, w, h);
 	}


### PR DESCRIPTION
Sean,

Please see the following.  This makes goomwwm respect a client's resize_inc setting, although it does so unconditionally.  I am not sure of the best way of representing this as an option to toggle on or off (as a -rule, perhaps?) so have left that open-ended for now.

But this should at least show the intent.

Interesting how the resize_inc setting affects a window going through a grow/shrink cycle using Shift+Pgup/Pgdown.  I rather like it, and it means I can have a window the full size of the screen without it actually being fullscreen unless I ask the window to.

Kindly,

-- Thomas Adam

Commit message:

Quite a few XClients set resize increment hints for the size of windows.
Honour them.
