### PR TITLE
Add option "follow" to parameter "warpmode"

### DIFF
--- a/goomwwm.1
+++ b/goomwwm.1
@@ -1489,9 +1489,14 @@ Pointer is never moved (default for -focusmode click).
 .RS
 .RE
 .TP
+.B follow
+Pointer follows a moved window, but is not moved to a newly focused window.
+.RS
+.RE
+.TP
 .B focus
-Pointer is warped to a newly focused window (default for -focusmode
-sloppy[tag]).
+Pointer is warped to a newly focused window, and follows a moved window
+(default for -focusmode sloppy[tag]).
 .RS
 .RE
 .RE

--- a/goomwwm.h
+++ b/goomwwm.h
@@ -232,6 +232,7 @@ typedef struct {
 #define RAISECLICK 2
 #define MAPSTEAL 1
 #define MAPBLOCK 2
+#define WARPFOLLOW 2
 #define WARPFOCUS 1
 #define WARPNEVER 0
 #define PLACEANY 1

--- a/handle.c
+++ b/handle.c
@@ -618,7 +618,9 @@ void handle_configurenotify(XEvent *ev)
 		{
 			client_review_border(c);
 			client_review_position(c);
-			if (c->active && config_warp_mode == WARPFOCUS && !mouse_dragger)
+			if (c->active && !mouse_dragger &&
+				(config_warp_mode == WARPFOCUS ||
+					config_warp_mode == WARPFOLLOW))
 			{
 				client_warp_pointer(c);
 				// dump any enterynotify events that have been generated

--- a/wm.c
+++ b/wm.c
@@ -264,6 +264,7 @@ void setup_general_options(int ac, char *av[])
 	config_warp_mode = WARPNEVER;
 	mode = find_arg_str(ac, av, "-warpmode", config_focus_mode == FOCUSCLICK ? "never": "focus");
 	if (!strcasecmp(mode, "focus")) config_warp_mode = WARPFOCUS;
+	if (!strcasecmp(mode, "follow")) config_warp_mode = WARPFOLLOW;
 
 	// steal mode
 	config_map_mode = MAPSTEAL;


### PR DESCRIPTION
I wanted to be able to use focusmode sloppy and move windows around with the keyboard (like with warpmode focus) without getting my mouse warped when I change focus.
