### PR TITLE
Guard box_hide call on client_close

### DIFF
--- a/client.c
+++ b/client.c
@@ -355,7 +355,7 @@ void client_close(client *c)
 	// prevent frame flash
 	c->active = 0;
 	client_redecorate(c);
-	box_hide(c->cache->frame);
+	if (c->cache->frame) box_hide(c->cache->frame);
 
 	if (c->cache->have_closed || !client_protocol_event(c, atoms[WM_DELETE_WINDOW]))
 		XKillClient(display, c->window);


### PR DESCRIPTION
I found that when I close Google Chrome (42.0.2311.152 64-bit) on Ubuntu (14.10, 15.04) using Mod-Escape, goomwwm crashes and leaves me back at the login screen. I swapped my install for a debug build and found the following in my syslog:

    May 17 00:03:53 gridge kernel: [ 2347.844741] goomwwm[10135]: segfault at 8 ip 0000000000403969 sp 00007ffc6fc28b18 error 4 in goomwwm[400000+19000]

I used addr2line to lead me to box.c:67 (box_hide), and found the offending caller to be client_close. I've added a guard around the box_hide call (like in client_review_border). The segfault no-longer happens.
