### PR TITLE
Fix compilation with GCC 15

### DIFF
--- a/goomwwm.h
+++ b/goomwwm.h
@@ -34,6 +34,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/cursorfont.h>
 #include <X11/XKBlib.h>
 #include <X11/Xft/Xft.h>
+#include <stddef.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,7 +51,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <err.h>
 #include <X11/extensions/Xinerama.h>
 
-typedef unsigned char bool;
 typedef unsigned long long bitmap;
 
 #define BOX_OVERRIDE 1<<0
@@ -289,7 +290,7 @@ typedef struct _winundo {
 // every window we know about gets one of these, even if it's empty
 typedef struct {
 	bool have_closed;  // true when we've previously politely sent a close request
-	bool last_corner;  // the last screen corner, used to make corner seem sticky during resizing
+	int last_corner;   // the last screen corner, used to make corner seem sticky during resizing
 	bool hlock, vlock; // horizontal and vertical size/position locks
 	bool has_mapped;   // true when a client has mapped previously. used to avoid applying rules
 	unsigned int tags; // desktop tags

--- a/wm.c
+++ b/wm.c
@@ -314,7 +314,7 @@ void setup_general_options(int ac, char *av[])
 	}
 
 	// app_find_or_start() keys
-	for (i = 0; config_apps_keysyms[i]; i++)
+	for (i = 0; i < (sizeof(config_apps_keysyms)/sizeof(KeySym)) - 1; i++)
 	{
 		char tmp[3]; sprintf(tmp, "-%d", i);
 		config_apps_patterns[i ? i-1: 9] = find_arg_str(ac, av, tmp, NULL);


### PR DESCRIPTION
Fix some errors and warnings when compiling goomwwm with GCC 15, which defaults to the C23 language standard.